### PR TITLE
Fix nullTTStub ref issue

### DIFF
--- a/L1Trigger/TrackFindingTracklet/interface/ChannelAssignment.h
+++ b/L1Trigger/TrackFindingTracklet/interface/ChannelAssignment.h
@@ -47,6 +47,8 @@ namespace trklet {
     // sets layerId (0-7 in sequence the seed type projects to) of given TTStubRef and seedType, returns false if seeed stub
     bool layerId(int seedType, const TTStubRef& ttStubRef, int& layerId) const;
     // number layers a given seed type projects to
+    int numSeedingLayers(int seedType) const { return (int)seedTypesSeedLayers_.at(seedType).size(); }
+    // number layers a given seed type projects to
     int numProjectionLayers(int seedType) const { return (int)seedTypesProjectionLayers_.at(seedType).size(); }
     // max. no. layers that any seed type projects to
     int maxNumProjectionLayers() const { return maxNumProjectionLayers_; }

--- a/L1Trigger/TrackFindingTracklet/python/ChannelAssignment_cfi.py
+++ b/L1Trigger/TrackFindingTracklet/python/ChannelAssignment_cfi.py
@@ -9,7 +9,7 @@ ChannelAssignment_params = cms.PSet (
     # The order here approximately dictates the order in which tracks enter the DR,
     # with DR keeping 1st track to arrive, in case two tracks are duplicate.
     MuxOrder    = cms.vstring( "L1L2", "L2L3", "L1D1", "D1D2", "D3D4", "L2D1", "L3L4", "L5L6", "L3L4L2","L5L6L4", "L2L3D1", "D1D2L2" ),
-    NumLayers   = cms.int32( 11 ), # number of layers per track
+    NumLayers   = cms.int32( 15 ), # number of layers per track
     WidthStubId = cms.int32( 10 ), # number of bits used to represent stub id for projected stubs
     WidthCot    = cms.int32( 14 )
   ),

--- a/L1Trigger/TrackFindingTracklet/src/TrackMultiplexer.cc
+++ b/L1Trigger/TrackFindingTracklet/src/TrackMultiplexer.cc
@@ -197,10 +197,14 @@ namespace trklet {
           }
         }
         // create fake seed stubs, since TrackBuilder doesn't output these stubs, required by the KF.
-        for (int seedingLayer = 0; seedingLayer < numS; seedingLayer++) {
+        for (int seedingLayer = 0; seedingLayer < channelAssignment_->numSeedingLayers(channel); seedingLayer++) {
           const int channelStub = numP + seedingLayer;
           const FrameStub& frameStub = streamsStub[offsetStub + channelStub][frame];
           const TTStubRef& ttStubRef = frameStub.first;
+          if (!ttStubRef.isNonnull()) {
+            edm::LogError("TrackMultiplexer") << "No ttStubRef for the seeding stub at seedingLayer " << seedingLayer << " found!";
+            return;
+          }
           const int trackletLayerId = setup_->trackletLayerId(ttStubRef);
           const int layerId = channelAssignment_->layerId(channel, channelStub);
           const int stubId = TTBV(frameStub.second).val(channelAssignment_->tmWidthStubId());


### PR DESCRIPTION
Fix the issue mentioned [here](https://github.com/cms-L1TK/cmssw/pull/321#issuecomment-3057916331).
The cause was that the ChannelAssignment class returns the maximum number of layers among all the seeds as numSeedingLayers. Consequently, when you add triplet seeds to the list, it will search for the third seeding stub also when looking at the doublet seeds. 
I've added a function which returns the number of seeding layers per seed, following the same approach used for the numProjectionLayers function, and I've used it in the relevant part of the code.
I'll let @tschuh comment if that's appropriate, and if it should be changed in other places where the variable numS is currently used.
